### PR TITLE
Enable Travis CI for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .directory
 __pycache__
+.cache
+
 library_coverage_xml_and_fulltext_indicators.db*
 downloader_configuration_file.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: trusty
+sudo: false
+language: generic
+before_install:
+  - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh
+    --output-document miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda info --all
+install:
+  - conda env create --quiet --file=environment.yml
+  - source activate library-access
+script:
+  - pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Data on Library Access to Scholarly Literature
 
+[![Build Status](https://travis-ci.org/greenelab/library-access.svg?branch=master)](https://travis-ci.org/greenelab/library-access)
+
 This repository is cataloging University Library access to scholarly literature.
 Scholarly articles are identified using their DOIs.
 The impetus for this project was [this discussion](https://github.com/greenelab/scihub-manuscript/issues/21 "Potential followup: comparison to authorized access") on the Sci-Hub Coverage Study.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ This repository is cataloging University Library access to scholarly literature.
 Scholarly articles are identified using their DOIs.
 The impetus for this project was [this discussion](https://github.com/greenelab/scihub-manuscript/issues/21 "Potential followup: comparison to authorized access") on the Sci-Hub Coverage Study.
 
-# License
+## Environment
+
+This repository uses [conda](http://conda.pydata.org/docs/) to manage its environment as specified in [`environment.yml`](environment.yml).
+Install the environment with:
+
+```sh
+conda env create --file=environment.yml
+```
+
+Then use `source activate library-access` and `source deactivate` to activate or deactivate the environment.
+On windows, use `activate library-access` and `deactivate` instead.
+
+## License
 
 The files in this repository are released under the CC0 1.0 public domain dedication ([`LICENSE-CC0.md`](LICENSE-CC0.md)), excepting those that match the glob patterns listed below.
 Files matching the following glob patters are instead released under a BSD 3-Claue license ([`LICENSE-BSD-3-Clause.md`](LICENSE-BSD-3-Clause.md)):

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,11 @@ name: library-access
 dependencies:
 - anaconda::beautifulsoup4=4.6.0
 - anaconda::ipython=5.3.0
+- anaconda::lxml=4.1.0
 - anaconda::pandas=0.20.1
 - anaconda::pep8=1.7.0
 - anaconda::pip=9.0.1
+- anaconda::pytest=3.2.1
 - anaconda::python=3.6.1
 - anaconda::r-base=3.4.1
 - anaconda::requests=2.14.2

--- a/library_management_system_downloader/test_evaluate_api_response_for_fulltext_indication.py
+++ b/library_management_system_downloader/test_evaluate_api_response_for_fulltext_indication.py
@@ -1,8 +1,14 @@
+import pytest
+
 import evaluate_api_response_for_fulltext_indication as to_test
 
 
-def test_fulltext_indication():
-    assert to_test.fulltext_indication(
-            '<key id="full_text_indicator">true</key>') == 1
-
-    assert to_test.fulltext_indication('tester') == 0
+@pytest.mark.parametrize(['xml', 'fulltext'], [
+    ('<key id="full_text_indicator">true</key>', 1),
+    ('<wrapper><key id="full_text_indicator">true</key></wrapper>', 1),
+    ('<key id="full_text_indicator">false</key>', 0),
+    ('tester', 0),
+    ('', 0),
+])
+def test_fulltext_indication(xml, fulltext):
+    assert to_test.fulltext_indication(xml) == fulltext


### PR DESCRIPTION
@publicus can you review this.

The purpose is to use TravisCI to automate the testing. This way if a PR breaks the environment or tests, we'll know it.