### PR TITLE
Added dependency for download script. 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
 - pip:
   - backoff==1.4.3
   - ratelimit==1.4.1
+  - lxml==3.7.3


### PR DESCRIPTION
I just tried using the download script on a fresh computer (to run the downloads on my desktop vs. my laptop), and it turns out `lxml` needs to be listed, as well. It was installed on my laptop, but I didn't remember / notice it when paring down the `environment.yml` file that Conda automatically initially created.